### PR TITLE
refactor(BBD-799): Simplify tag selectors

### DIFF
--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -23,11 +23,11 @@ class Collections {
 
   updateCollections = () =>
     this.set({
-      collections: this.selectCollections(Selectors.collections(this.flux.store.getState()))
+      collections: this.selectCollections(this.select(Selectors.collections))
     })
 
   updateCollectionTotal = ({ name, total }: Store.Collection) => {
-    const index = Selectors.collectionIndex(this.flux.store.getState(), name);
+    const index = this.select(Selectors.collectionIndex, name);
     const collections = this.state.collections.slice();
 
     collections.splice(index, 1, { ...this.state.collections[index], total });

--- a/test/unit/collections.ts
+++ b/test/unit/collections.ts
@@ -89,13 +89,13 @@ suite('Collections', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveA
       const rawCollections = ['e', 'f'];
       const set = collections.set = spy();
       const selectCollections = collections.selectCollections = spy(() => newCollections);
-      const collectionsSelector = stub(Selectors, 'collections').returns(rawCollections);
+      const select = collections.select = spy(() => rawCollections);
       collections.flux = <any>{ store: { getState: () => state } };
 
       collections.updateCollections();
 
       expect(selectCollections).to.be.calledWith(rawCollections);
-      expect(collectionsSelector).to.be.calledWith(state);
+      expect(select).to.be.calledWith(Selectors.collections);
       expect(set).to.be.calledWith({ collections: newCollections });
     });
   });
@@ -105,13 +105,13 @@ suite('Collections', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveA
       const allIds = ['a', 'b', 'c'];
       const set = collections.set = spy();
       const state = { j: 'k' };
-      const collectionsSelector = stub(Selectors, 'collectionIndex').returns(1);
+      const select = collections.select = spy(() => 1);
       collections.flux = <any>{ store: { getState: () => state } };
       collections.state = <any>{ collections: [{ d: 'e' }, { f: 'g' }, { h: 'i' }] };
 
       collections.updateCollectionTotal({ name: 'b', total: 50 });
 
-      expect(collectionsSelector).to.be.calledWith(state);
+      expect(select).to.be.calledWith(Selectors.collectionIndex);
       expect(set).to.be.calledWith({ collections: [{ d: 'e' }, { f: 'g', total: 50 }, { h: 'i' }] });
     });
   });


### PR DESCRIPTION
The BBD-799 PRs:
* https://github.com/groupby/storefront-collections/pull/16
* https://github.com/groupby/storefront-navigation/pull/31
* https://github.com/groupby/storefront-page-size/pull/15
* https://github.com/groupby/storefront-query/pull/27
* https://github.com/groupby/storefront-recommendations/pull/7
* https://github.com/groupby/storefront-record-count/pull/18
* https://github.com/groupby/storefront-sayt/pull/34
* https://github.com/groupby/storefront-sort/pull/17
* https://github.com/groupby/storefront-structure/pull/37
* https://github.com/groupby/storefront-breadcrumbs/pull/20
