### PR TITLE
fix(SF-1065): Remove padding from interpolated braces in the HTML templates

### DIFF
--- a/src/collections/index.html
+++ b/src/collections/index.html
@@ -1,7 +1,7 @@
 <yield>
-  <gb-select options="{ state.collections }" on-select="{ state.onSelect }">
-    <gb-custom-select _props="{ childProps() }">
-      <gb-collections-option _props="{ $option }"></gb-collections-option>
+  <gb-select options="{state.collections}" on-select="{state.onSelect}">
+    <gb-custom-select _props="{childProps()}">
+      <gb-collections-option _props="{$option}"></gb-collections-option>
     </gb-custom-select>
   </gb-select>
 </yield>

--- a/src/option/index.html
+++ b/src/option/index.html
@@ -1,2 +1,2 @@
-<span>{ props.label }</span>
-<gb-badge total="{ props.total }">{ props.total }</gb-badge>
+<span>{props.label}</span>
+<gb-badge total="{props.total}">{props.total}</gb-badge>


### PR DESCRIPTION
This fixes potential syntax errors coming from Riot.